### PR TITLE
Add fix to docker compose file for WSL2

### DIFF
--- a/samples/openai-acs-msgraph/docker-compose.yml
+++ b/samples/openai-acs-msgraph/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       POSTGRES_USER: web
       POSTGRES_PASSWORD: web-password
       POSTGRES_DB: CustomersDB
+      PGDATA: /var/lib/pg_data
     volumes:
       - ./data:/var/lib/postgresql/data
     ports:


### PR DESCRIPTION
 Update docker-compose.yml to support Docker Desktop running on WSL2 (permissions error).

Hi @DanWahlin I was in your workshop session on Monday (I was the one having the issues with WSL2). I met with another participant later (our friend from Japan) who figured out this fix. It now works on my machine. I'm unsure if this will break other configurations.